### PR TITLE
Fix completionModel to use config

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"publisher": "SublimeSecurity",
 	"license": "MIT",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"icon": "icon.png",
 	"repository": {
 		"type": "git",
@@ -127,7 +127,7 @@
 					"type": "string",
 					"description": "The model to use for OpenAI code completions",
 					"title": "Completion Model",
-					"default": "curie:ft-sublime-security-2023-04-21-20-26-44",
+					"default": "curie:ft-sublime-security-2023-08-05-00-34-40",
 					"order": 5
 				}
 			}


### PR DESCRIPTION
Before it was hardcoded to the new model, now it's using the one in the settings. I confirmed it's completing based on the latest functions we have available.

```rust
// attachments contain logos to Microsoft
any(attachments, any(ml.logo_detect(.).brands, .name == "Microsoft"))
```